### PR TITLE
[WIP]/[Suggestion] Add convenience functions for exchanging custom for id_token for sign in of client

### DIFF
--- a/lib/firebase_dart.dart
+++ b/lib/firebase_dart.dart
@@ -6,3 +6,4 @@
 library firebase_dart;
 
 export 'src/firebase.dart';
+export 'src/connection.dart';

--- a/lib/src/firebase/firebase.dart
+++ b/lib/src/firebase/firebase.dart
@@ -27,6 +27,14 @@ abstract class Firebase implements Query {
   /// resolved when the authentication succeeds (or fails).
   Future<Map> authWithCustomToken(String token);
 
+  /// Authenticates a Firebase client using an custom token created by the admin sdk.
+  /// Returns a JWT id_token that is accepted by [authWithCustomToken]
+  Future<Map<String, dynamic>> exchangeCustomToken(String token, String apiKey);
+
+  /// Refresh a token retrieved with [exchangeCustomToken].
+  /// The id_token is typically valid 1h, but can be refreshed indefinitely.
+  Future<Map<String, dynamic>> refreshIdToken(String token, String apiKey);
+
   /// Synchronously retrieves the current authentication state of the client.
   dynamic get auth;
 

--- a/lib/src/firebase_impl.dart
+++ b/lib/src/firebase_impl.dart
@@ -111,6 +111,14 @@ class FirebaseImpl extends QueryImpl with Firebase {
   Future<Map> authWithCustomToken(String token) => _repo.auth(token);
 
   @override
+  Future<Map<String, dynamic>> exchangeCustomToken(String token, String apiKey) =>
+      _repo.exchangeCustomToken(token, apiKey);
+
+  @override
+  Future<Map<String, dynamic>> refreshIdToken(String refreshToken, String apiKey) =>
+      _repo.refreshIdToken(refreshToken, apiKey);
+
+  @override
   dynamic get auth => _repo.authData;
 
   @override

--- a/lib/src/repo.dart
+++ b/lib/src/repo.dart
@@ -15,6 +15,8 @@ import 'tree.dart';
 import 'event.dart';
 import 'operations/tree.dart';
 import 'package:sortedmap/sortedmap.dart';
+import 'dart:convert';
+import 'package:http/http.dart' as http;
 
 final _logger = new Logger("firebase-repo");
 
@@ -89,6 +91,39 @@ class Repo {
     _onAuth.add(auth);
     _authData = auth;
     return auth;
+  }
+
+  Future<Map<String, dynamic>> exchangeCustomToken(token, apiKey) async {
+    var idToken = await http.post(
+        "https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=$apiKey",
+        body: jsonEncode({"token": token, "returnSecureToken": true}),
+        headers: {'Content-Type': 'application/json'});
+    if (idToken.statusCode == 200) {
+      try {
+        return jsonDecode(idToken.body);
+      } on FormatException catch (e) {
+        print(e);
+      }
+    } else {
+      // do something with error code?
+    }
+    return null;
+  }
+
+  Future<Map<String, dynamic>> refreshIdToken(refreshToken, apiKey) async {
+    var idToken = await http.post("https://securetoken.googleapis.com/v1/token?key=$apiKey",
+        body: {"refresh_token": refreshToken, "grant_type": "refresh_token"},
+        headers: {'Content-Type': 'application/x-www-form-urlencoded '});
+    if (idToken.statusCode == 200) {
+      try {
+        return jsonDecode(idToken.body);
+      } on FormatException catch (e) {
+        print(e);
+      }
+    } else {
+      // do something with error code?
+    }
+    return null;
   }
 
   /// Unauthenticates.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   collection: '^1.9.1'
   meta: '^1.1.5'
   dart2_constant: ^1.0.0
+  http: '^0.12.0+2'
 
 dev_dependencies:
   test: '>=0.12.0 <2.0.0'


### PR DESCRIPTION
To be able to use firebase_dart from an end user client for a user created/authenticated via the admin sdk on a back-end service (cloud function), (for example with some external oauth provider), I needed to be able to sign in with the customToken the admin sdk provides. 
I thought the existing function authWithCustomToken would do that, but it appears to be somewhat of a misnomer, as it takes an access token, or a secret admin key thing (whatever they call it).

I wanted your input on if there's a nice place to add the 2 functions in my PR, to wrap it nicely inside the lib somehow, or if it will have to remain as outside/util funcs. It would be neat if the library had a way to keep track of the token and refresh it when necessary so the app didn't have to. 
The js-sdk seems to do it, looking at https://github.com/firebase/firebase-js-sdk/blob/fa3fc0fa8760cf159e47b7860e00861205dbf55a/packages/auth/src/auth.js#L1511 
and
https://github.com/firebase/firebase-js-sdk/blob/9b8ef5997b6146c46c7638bc1d61c47452c34058/packages/auth/src/rpchandler.js

Thoughts?