### PR TITLE
Remove use of discontinued package dart2_constant

### DIFF
--- a/lib/src/connections/protocol.dart
+++ b/lib/src/connections/protocol.dart
@@ -4,6 +4,7 @@
 library firebase.protocol;
 
 import 'dart:async';
+import 'dart:convert';
 import 'package:jose/jose.dart';
 import 'package:quiver/core.dart' as quiver;
 import 'package:quiver/check.dart' as quiver;
@@ -18,7 +19,6 @@ import 'dart:math';
 import '../treestructureddata.dart';
 import 'package:sortedmap/sortedmap.dart';
 import '../connection.dart';
-import 'package:dart2_constant/convert.dart';
 import 'package:meta/meta.dart';
 
 part 'protocol/request.dart';

--- a/lib/src/firebase.dart
+++ b/lib/src/firebase.dart
@@ -4,13 +4,12 @@
 library firebase_dart;
 
 import 'dart:async';
-import 'dart:convert' show Converter, Codec;
+import 'dart:convert';
 import 'package:crypto/crypto.dart';
 import 'dart:collection';
 import 'firebase_impl.dart';
 import '../firebase_core.dart';
 import 'package:quiver/core.dart' as quiver;
-import 'package:dart2_constant/convert.dart';
 
 part 'firebase/datasnapshot.dart';
 

--- a/lib/src/treestructureddata.dart
+++ b/lib/src/treestructureddata.dart
@@ -9,8 +9,8 @@ import 'package:sortedmap/sortedmap.dart';
 import 'tree.dart';
 import 'package:quiver/core.dart' as quiver;
 import 'dart:typed_data';
+import 'dart:convert';
 import 'package:crypto/crypto.dart';
-import 'package:dart2_constant/convert.dart';
 
 part 'treestructureddata/name.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,6 @@ dependencies:
   isolate: '>=1.1.0 <3.0.0'
   collection: '^1.9.1'
   meta: '^1.1.5'
-  dart2_constant: ^1.0.0
   jose: ^0.1.2
 
 dev_dependencies:

--- a/test/firebase.dart
+++ b/test/firebase.dart
@@ -8,11 +8,11 @@ import 'package:firebase_dart/firebase_core.dart';
 import 'package:logging/logging.dart';
 import 'dart:math';
 import 'dart:async';
+import 'dart:convert';
 
 import 'secrets.dart'
     if (dart.library.html) 'secrets.dart'
     if (dart.library.io) 'secrets_io.dart' as s;
-import 'package:dart2_constant/convert.dart';
 import 'package:firebase_dart/src/connections/protocol.dart';
 
 void main() {

--- a/test/secrets_io.dart
+++ b/test/secrets_io.dart
@@ -1,5 +1,5 @@
 import 'dart:io';
-import 'package:dart2_constant/convert.dart';
+import 'dart:convert';
 
 Map get secrets {
   var f = File('test/secrets.json');


### PR DESCRIPTION
Removes the use of https://pub.dev/packages/dart2_constant, which has been marked DISCONTINUED. It doesnt look like that package is needed any longer anyway?