### PR TITLE
fix: Firebase emulators report port in addition to host

### DIFF
--- a/packages/firebase_dart/lib/src/database/impl/connections/protocol/persistent_connection.dart
+++ b/packages/firebase_dart/lib/src/database/impl/connections/protocol/persistent_connection.dart
@@ -84,7 +84,14 @@ class PersistentConnectionImpl extends PersistentConnection
 
   @override
   void onCacheHost(String? host) {
-    _url = _url.replace(host: host);
+    final hostPort = host?.split(':');
+    String? newHost;
+    int? port;
+    if (hostPort != null) {
+      newHost = hostPort.length >= 1 ? hostPort[0] : null;
+      port = hostPort.length > 1 ? int.parse(hostPort[1]) : null;
+    }
+    _url = _url.replace(host: newHost, port: port);
   }
 
   @override


### PR DESCRIPTION
Firebase emulators report the host as 127.0.0.1:theportnumber

Previously _uri.replace would throw because ports are not valid in a host. This fixes that.