### PR TITLE
Pure dart, firebase storage. Fix custom metadata conversion in POST

### DIFF
--- a/packages/firebase_dart/lib/src/storage/backend/backend.dart
+++ b/packages/firebase_dart/lib/src/storage/backend/backend.dart
@@ -67,7 +67,8 @@ class BackendConnection {
                     contentEncoding: metadata['contentEncoding'],
                     contentLanguage: metadata['contentLanguage'],
                     contentType: metadata['contentType'] ?? contentType,
-                    customMetadata: metadata['customMetadata']),
+                    customMetadata:
+                        (metadata['customMetadata'] as Map?)?.cast()),
               );
 
               var fullMetadata = await backend.getMetadata(location);

--- a/packages/firebase_dart/test/storage/storage_test.dart
+++ b/packages/firebase_dart/test/storage/storage_test.dart
@@ -195,6 +195,16 @@ void runStorageTests({bool isolated = false}) {
         expect(t.metadata!.contentType, 'lol/wut');
       });
 
+      test('Uses custom metadata', () async {
+        var customMetadata = {'one': '1', 'two': '2'};
+        var t = await child.child('hello.bin').putData(
+              Uint8List(0),
+              SettableMetadata(customMetadata: customMetadata),
+            );
+        var r = await child.child('hello.bin').getMetadata();
+        expect(r.customMetadata, customMetadata);
+      });
+
       test('uploads without error', () async {
         var blob = Uint8List.fromList([97]);
         var ref = child.child('hello.bin');


### PR DESCRIPTION
Setting custom metadata to Firebase storage doesn't work.