### PR TITLE
Fixes for #62 and #63

### DIFF
--- a/packages/firebase_dart/lib/src/auth/usermanager.dart
+++ b/packages/firebase_dart/lib/src/auth/usermanager.dart
@@ -39,7 +39,14 @@ class UserManager {
   }
 
   Future<void> _init() async {
-    var storage = await this.storage;
+    final storage = await this.storage;
+    final response = await (await storage).get(_key);
+
+    final currentUser = response == null
+        ? null
+        : FirebaseUserImpl.fromJson({...response}, auth: auth);
+
+    _controller.add(currentUser);
 
     _subscription = storage
         .watch(key: _key)

--- a/packages/firebase_dart/lib/src/core/impl/persistence.dart
+++ b/packages/firebase_dart/lib/src/core/impl/persistence.dart
@@ -4,14 +4,31 @@ import 'package:hive/hive.dart';
 
 class PersistenceStorage {
   static bool _memoryStorage = false;
+
+  static final _openBoxes = <String, Box>{};
+
   static Future<Box> openBox(String name) async {
+    final openBox = _openBoxes[name];
+
+    if (openBox != null) return openBox;
+
+    Future<Box> getBox() async {
+      final box = await Hive.openBox(
+        name,
+        bytes: _memoryStorage ? Uint8List(0) : null,
+      );
+
+      await box.compact();
+
+      return _openBoxes[name] = box;
+    }
+
     try {
-      return await Hive.openBox(name,
-          bytes: _memoryStorage ? Uint8List(0) : null);
+      return await getBox();
     } on HiveError {
       await Hive.deleteBoxFromDisk(name);
-      return await Hive.openBox(name,
-          bytes: _memoryStorage ? Uint8List(0) : null);
+
+      return await getBox();
     }
   }
 

--- a/packages/firebase_dart/pubspec.yaml
+++ b/packages/firebase_dart/pubspec.yaml
@@ -7,35 +7,35 @@ environment:
   sdk: '>=2.19.0 <3.0.0'
 
 dependencies:
-  quiver: ^3.0.0
-  async: ^2.5.0
-  logging: ^1.0.0
-  sortedmap: ^0.5.2
-  web_socket_channel: '>=2.0.0 <4.0.0'
-  stream_channel: ^2.1.0
-  collection: ^1.15.0
-  meta: ^1.3.0
-  jose: ^0.3.2
-  clock: ^1.1.0
-  firebaseapis: ">=0.1.2 <0.3.0"
-  openid_client: ^0.4.3
-  hive: ^2.0.0
-  rxdart: ">=0.27.0 <0.29.0"
-  http: ">=0.13.0 <2.0.0"
-  _discoveryapis_commons: ^1.0.0
-  expressions: ^0.2.2
-  uuid: ">=3.0.1 <5.0.0"
-  crypto: ^3.0.0
-  js: ">=0.6.3 <0.8.0"
-  synchronized: ^3.0.0
-  intl: ">=0.17.0 <0.21.0"
+  quiver: ^3.2.2
+  async: ^2.13.0
+  logging: ^1.3.0
+  sortedmap: ^0.5.4
+  web_socket_channel: ^3.0.3
+  stream_channel: ^2.1.4
+  collection: ^1.19.1
+  meta: ^1.16.0
+  jose: ^0.3.4
+  clock: ^1.1.2
+  firebaseapis: ^0.2.0
+  openid_client: ^0.4.9
+  hive: ^2.2.3
+  rxdart: ^0.28.0
+  http: ^1.4.0
+  _discoveryapis_commons: ^1.0.7
+  expressions: ^0.2.5+2
+  uuid: ^4.5.1
+  crypto: ^3.0.6
+  js: ^0.7.2
+  synchronized: ^3.4.0
+  intl: ^0.20.2
 
 dev_dependencies:
-  test: ^1.16.5
-  fake_async: ^1.2.0
-  benchmark_harness: ^2.0.0
-  vm_service: ">=9.0.0 <15.0.0"
-  lints: ">=2.0.0 <5.0.0"
+  test: ^1.26.3
+  fake_async: ^1.3.3
+  benchmark_harness: ^2.3.1
+  vm_service: ^15.0.2
+  lints: ^6.0.0
 
 false_secrets:
  - /lib/src/core/options.dart

--- a/packages/firebase_dart_flutter/test/firebase_dart_flutter_test.dart
+++ b/packages/firebase_dart_flutter/test/firebase_dart_flutter_test.dart
@@ -1,1 +1,0 @@
-void main() {}


### PR DESCRIPTION
Fixes #62 by loading the current user in `init` and adding it to the stream (from where the `currentUser` is get).

Fixes #63 by compacting the Hive database on open (and added a cache for the open boxes so they are not opened and compacted every single time).